### PR TITLE
issue#252: Add Loader on "My Trips" Page

### DIFF
--- a/src/scenes/account/components/AccountTripsScene.js
+++ b/src/scenes/account/components/AccountTripsScene.js
@@ -21,7 +21,7 @@ const AutoLink = styled(Link)`
 class AccountTripsScene extends Component {
   static propTypes = {
     allTrips: PropTypes.array,
-    //isLoadingTrips: PropTypes.bool.isRequired,
+    isLoadingTrips: PropTypes.bool.isRequired,
   };
 
   static defaultProps = {

--- a/src/scenes/account/containers/AccountTripsContainer.js
+++ b/src/scenes/account/containers/AccountTripsContainer.js
@@ -17,6 +17,7 @@ class AccountTripsContainer extends Component {
 
 const mapStateToProps = state => ({
   allTrips: state.AccountReducer.allTrips,
+  isLoadingTrips: state.AccountReducer.isLoadingTrips,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators(accountActions, dispatch);

--- a/src/styled_scenes/Account/Trips/shared/TripSectionComponent.js
+++ b/src/styled_scenes/Account/Trips/shared/TripSectionComponent.js
@@ -51,6 +51,10 @@ const ColoredText = styled.p`
   color: #b3a7a7;
 `;
 
+const LoaderWrapper = styled.div`
+  margin-top: 100px;
+`;
+
 class Trip extends Component {
   static propTypes = {
     trip: PropTypes.object.isRequired,
@@ -109,9 +113,11 @@ class Trip extends Component {
 const TripSectionComponent = props => {
   if (props.isLoadingTrips) {
     return (
-      <Loader active inline="centered" size="massive">
-        Loading
-      </Loader>
+      <LoaderWrapper>
+        <Loader active inline="centered" size="big">
+          Loading
+        </Loader>
+      </LoaderWrapper>
     );
   }
   if (!props.trips.length) {


### PR DESCRIPTION
https://github.com/PleaseDotCom/frontend/issues/252
While fetching the trips of a user, we would like the page to show a loading spinner. Everything was in place in the case of actions and reducers. The only missing part was that it was not passed down to the presentational component from the connected one.

I wanted to add a margin of 100px and the only way I could figure out was to add a wrapper around `Loader` component, but I think there should be a nicer way to do it and I appreciate help on that please.

<img width="1423" alt="screenshot 2018-10-27 at 12 54 46" src="https://user-images.githubusercontent.com/15628074/47603110-9a0cc100-d9e7-11e8-9ce4-f9444abf9b03.png">
